### PR TITLE
fix: Default's parent_pricing_policy method

### DIFF
--- a/apps/partner/strategy.py
+++ b/apps/partner/strategy.py
@@ -37,9 +37,10 @@ class Default(CoreDefault):
             return self.convert_currency(stockrecord, prices)
         return prices
 
-    def parent_pricing_policy(self, product, stockrecord):
-        prices = super().parent_pricing_policy(product, stockrecord)
-        if stockrecord:
+    def parent_pricing_policy(self, product, children_stock):
+        prices = super().parent_pricing_policy(product, children_stock)
+        if children_stock:
+            stockrecord = children_stock[0][1]  # take first record
             currency = self.get_currency()
             if currency == stockrecord.price_currency:
                 return prices


### PR DESCRIPTION
The method was not written correctly.
It threw an error "List object has no attribute price_currency"
on catalogue:index and catalogue:category views. 

The error was caused by method's incorrect processing
of 'stockrecord' argument, that is now renamed to children_stock
as in Oscar's source. The method called tried to get .price_currency
from children_stock list.

The fix takes the first stockrecord from children_stock, which
fixes the error.